### PR TITLE
IP-433 Stats Credentials

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -56,6 +56,7 @@ log_connections = ${PGBOUNCER_LOG_CONNECTIONS:-1}
 log_disconnections = ${PGBOUNCER_LOG_DISCONNECTIONS:-1}
 log_pooler_errors = ${PGBOUNCER_LOG_POOLER_ERRORS:-1}
 stats_period = ${PGBOUNCER_STATS_PERIOD:-60}
+stats_users = ${PGBOUNCER_STATS_USER}
 [databases]
 EOFEOF
 

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -103,5 +103,12 @@ EOFEOF
   let "n += 1"
 done
 
+# add PGBOUNCER_STATS_USER to users.txt
+PGBOUNCER_STATS_PASSWORD_MD5="md5"`echo -n ${PGBOUNCER_STATS_PASSWORD}${PGBOUNCER_STATS_USER} | md5sum | awk '{print $1}'`
+
+cat >> /app/vendor/pgbouncer/users.txt << EOFEOF
+"$PGBOUNCER_STATS_USER" "$PGBOUNCER_STATS_PASSWORD_MD5"
+EOFEOF
+
 chmod go-rwx /app/vendor/pgbouncer/*
 chmod go-rwx /app/vendor/stunnel/*

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -110,10 +110,6 @@ cat >> /app/vendor/pgbouncer/users.txt << EOFEOF
 "$PGBOUNCER_STATS_USER" "$PGBOUNCER_STATS_PASSWORD_MD5"
 EOFEOF
 
-# set PGBOUNCER_STATS_DATABASE_URL so datadog agent can pull stats
-# check https://github.com/deliveroo/heroku-buildpack-datadog for details on how it is used.
-export PGBOUNCER_STATS_DATABASE_URL=postgres://${PGBOUNCER_STATS_USER}:${PGBOUNCER_STATS_PASSWORD}@127.0.0.1:6000/pgbouncer
-
 chmod go-rwx /app/vendor/pgbouncer/*
 chmod go-rwx /app/vendor/stunnel/*
 

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -110,5 +110,10 @@ cat >> /app/vendor/pgbouncer/users.txt << EOFEOF
 "$PGBOUNCER_STATS_USER" "$PGBOUNCER_STATS_PASSWORD_MD5"
 EOFEOF
 
+# set PGBOUNCER_STATS_DATABASE_URL so datadog agent can pull stats
+# check https://github.com/deliveroo/heroku-buildpack-datadog for details on how it is used.
+export PGBOUNCER_STATS_DATABASE_URL=postgres://${PGBOUNCER_STATS_USER}:${PGBOUNCER_STATS_PASSWORD}@127.0.0.1:6000/pgbouncer
+
 chmod go-rwx /app/vendor/pgbouncer/*
 chmod go-rwx /app/vendor/stunnel/*
+

--- a/bin/start-pgbouncer-stunnel
+++ b/bin/start-pgbouncer-stunnel
@@ -70,7 +70,10 @@ run-pgbouncer() {
 }
 
 create-datadog-pgbouncer-integration-config() {
+  at create-datadog-pgbouncer-integration-config
+
   if [ -d /app/.apt/opt/datadog-agent/agent/conf.d/ ]; then
+    at writing-pgbouncer.yaml
     cat >> /app/.apt/opt/datadog-agent/agent/conf.d/pgbouncer.yaml << EOFEOF
 init_config:
 instances:
@@ -82,7 +85,9 @@ EOFEOF
 }
 
 restart-datadog-agent() {
+  at create-datadog-pgbouncer-integration-config
   if [ -f /app/bin/restart-datadog-agent.sh ]; then
+    at restart-datadog-agent.sh
     exec /app/bin/restart-datadog-agent.sh
   fi
 }

--- a/bin/start-pgbouncer-stunnel
+++ b/bin/start-pgbouncer-stunnel
@@ -7,14 +7,14 @@ main() {
     exec "$@"
   fi
 
-  at pgbouncer-enabled
-  run-pgbouncer "$@"
-
   if is-enabled "${PGBOUNCER_MONITORING_ENABLED:-1}"; then
     create-datadog-pgbouncer-integration-config
     restart-datadog-agent
     exec "$@"
   fi
+
+  at pgbouncer-enabled
+  run-pgbouncer "$@"
 }
 
 run-pgbouncer() {

--- a/bin/start-pgbouncer-stunnel
+++ b/bin/start-pgbouncer-stunnel
@@ -9,6 +9,12 @@ main() {
 
   at pgbouncer-enabled
   run-pgbouncer "$@"
+
+  if is-enabled "${PGBOUNCER_MONITORING_ENABLED:-1}"; then
+    create-datadog-pgbouncer-integration-config
+    restart-datadog-agent
+    exec "$@"
+  fi
 }
 
 run-pgbouncer() {
@@ -61,6 +67,24 @@ run-pgbouncer() {
     at "kill-aux name=$name pid=${pids[$name]} signal=${signals[$name]}"
     kill -SIGHUP "${pids[$name]}"
   done
+}
+
+create-datadog-pgbouncer-integration-config() {
+  if [ -d /app/.apt/opt/datadog-agent/agent/conf.d/ ]; then
+    cat >> /app/.apt/opt/datadog-agent/agent/conf.d/pgbouncer.yaml << EOFEOF
+init_config:
+instances:
+  - database_url:  postgres://${PGBOUNCER_STATS_USER}:${PGBOUNCER_STATS_PASSWORD}@127.0.0.1:6000/pgbouncer
+    tags:
+      - source:${DYNO}
+EOFEOF
+  fi
+}
+
+restart-datadog-agent() {
+  if [ -f /app/bin/restart-datadog-agent.sh ]; then
+    exec /app/bin/restart-datadog-agent.sh
+  fi
 }
 
 config-gen() {

--- a/bin/start-pgbouncer-stunnel
+++ b/bin/start-pgbouncer-stunnel
@@ -10,7 +10,6 @@ main() {
   if is-enabled "${PGBOUNCER_MONITORING_ENABLED:-1}"; then
     create-datadog-pgbouncer-integration-config
     restart-datadog-agent
-    exec "$@"
   fi
 
   at pgbouncer-enabled
@@ -70,10 +69,9 @@ run-pgbouncer() {
 }
 
 create-datadog-pgbouncer-integration-config() {
-  at create-datadog-pgbouncer-integration-config
 
   if [ -d /app/.apt/opt/datadog-agent/agent/conf.d/ ]; then
-    at writing-pgbouncer.yaml
+    at create-datadog-pgbouncer-integration-config
     cat >> /app/.apt/opt/datadog-agent/agent/conf.d/pgbouncer.yaml << EOFEOF
 init_config:
 instances:
@@ -85,10 +83,9 @@ EOFEOF
 }
 
 restart-datadog-agent() {
-  at create-datadog-pgbouncer-integration-config
   if [ -f /app/bin/restart-datadog-agent.sh ]; then
-    at restart-datadog-agent.sh
-    exec /app/bin/restart-datadog-agent.sh
+    at restart-datadog-agent
+    exec /app/bin/restart-datadog-agent.sh > /dev/null 2>&1 &
   fi
 }
 


### PR DESCRIPTION
Update the buildpack so  
- [x] The generated pgbouncer.ini file includes a stats_users username
- [x] the generated users.txt file includes the MD5 hash of the stats user's password
- [ ]  an environmental variable is defined so the agent can connect to pgbouncer with the appropriate user and password for the 'pgbouncer' database (similar to the DATABASE_URL_PGBOUNCER variable it currently creates)
 
New ENV params,

* PGBOUNCER_STATS_USER  
* PGBOUNCER_STATS_PASSWORD

[read in jira ...](https://deliveroo.atlassian.net/browse/IP-433)