### PR TITLE
Removed database_url from the Datadog integration config

### DIFF
--- a/bin/start-pgbouncer-stunnel
+++ b/bin/start-pgbouncer-stunnel
@@ -76,7 +76,10 @@ create-datadog-pgbouncer-integration-config() {
     cat >> /app/.apt/opt/datadog-agent/agent/conf.d/pgbouncer.yaml << EOFEOF
 init_config:
 instances:
-  - database_url:  postgres://${PGBOUNCER_STATS_USER}:${PGBOUNCER_STATS_PASSWORD}@127.0.0.1:6000/pgbouncer
+  - host: localhost
+    port: 6000
+    username: ${PGBOUNCER_STATS_USER}
+    password: ${PGBOUNCER_STATS_PASSWORD}
     tags:
       - source:${DYNO}
 EOFEOF


### PR DESCRIPTION
Datadog agent 5.9.1 doesn't read `database_url`  unlike the version 5.10.1.
In order to make the integration work for 5.9.1 (which is the version we use in production), I removed database_url