### PR TITLE
Gracefully handle database upgrades/failovers

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -85,6 +85,7 @@ do
   cat >> /app/vendor/stunnel/stunnel-pgbouncer.conf << EOFEOF
 [$POSTGRES_URL]
 client = yes
+delay = yes
 protocol = pgsql
 accept  = /tmp/.s.PGSQL.610${n}
 connect = $DB_HOST:$DB_PORT


### PR DESCRIPTION
When we upgrade database servers or they fail over, they can change IP address, but by default stunnel only looks them up upon startup.

set `delay=yes` in the stunnel config file to make sure it re-resolve database DNS on connection